### PR TITLE
Allow colons after section names

### DIFF
--- a/src/wipable.ts
+++ b/src/wipable.ts
@@ -13,7 +13,7 @@ export default abstract class Wipable {
 
   wipLimit() {
     const title = this.title();
-    const wipFinder = /.*\[(\d*)\]$/;
+    const wipFinder = /.*\[(\d*)\]:?$/;
     const results = wipFinder.exec(title);
     if (results !== null) {
       return parseInt(results[1], 10);


### PR DESCRIPTION
Allow old-school section names using colons at end of names, and still recognize the [wip-limit] at the end